### PR TITLE
Add custom postal_code regex for :lv

### DIFF
--- a/resources/custom/shared/postal_codes.yml
+++ b/resources/custom/shared/postal_codes.yml
@@ -1,3 +1,5 @@
 ---
 :pt:
   :regex: !ruby/regexp /\d{4}[\-]\d{3}/
+:lv:
+  :regex: !ruby/regexp /(LV[\s\-]?)?\d{4}/


### PR DESCRIPTION
Right now only 4 digit postcodes are accepted for Latvia.
This change will allow: 'LV 1234', 'LV-1234', 'LV1234'